### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ După ce parsați întreaga poezie, va trebui la final să afișați pentru toat
 - veți pune codul sursă pe un URL accesibil, dar private (un server, Dropbox sau [gist](https://gist.github.com) pe Github), și veți pune acest URL în formularul de înscriere
 - proiectul îl puteți face în orice limbaj doriți voi
 - dar, va trebui să conțină un `Makefile` care va genera un fișier executabil (un ghid scurt pentru utilitarul Make e [aici](http://mrbook.org/blog/tutorials/make/)), pe o mașină Linux Ubuntu
-- binarul va trebui să primească 2 parametrii, primul este fișierul de intrare, iar al doilea este fișierul de ieșire
+- binarul va trebui să primească 2 parametri, primul este fișierul de intrare, iar al doilea este fișierul de ieșire
 
 #### Testarea
 


### PR DESCRIPTION
E nearticulat, deci nu trebuie să fie cu doi _i_. :memo: 
